### PR TITLE
[#29] fix: 메인페이지의 점수 결과페이지로 전달 수정

### DIFF
--- a/pages/Main.py
+++ b/pages/Main.py
@@ -27,6 +27,8 @@ if "show_hint" not in st.session_state:
     st.session_state.show_hint = False
 if "feedback" not in st.session_state:
     st.session_state.feedback = None
+if "current_page" not in st.session_state:
+    st.session_state.current_page = "Main"
 
 # 퀴즈 시작 함수
 def start_quiz():
@@ -35,64 +37,74 @@ def start_quiz():
     st.session_state.current_question = 0
     st.session_state.show_hint = False
     st.session_state.feedback = None
-    # 선택된 난이도의 문제 필터링
     st.session_state.selected_questions = questions_data[st.session_state.selected_level]
     random.shuffle(st.session_state.selected_questions)
 
 # 메인 화면
-if not st.session_state.quiz_started:
-    st.title("옵션")
-    st.subheader("난이도 설정")
-    st.session_state.selected_level = st.selectbox(
-        "난이도를 선택하세요:", list(questions_data.keys())
-    )
-    if st.button("퀴즈 시작"):
-        start_quiz()
+def main_page():
+    if not st.session_state.quiz_started:
+        st.title("옵션")
+        st.subheader("난이도 설정")
+        st.session_state.selected_level = st.selectbox(
+            "난이도를 선택하세요:", list(questions_data.keys())
+        )
+        if st.button("퀴즈 시작"):
+            start_quiz()
 
-# 퀴즈 진행
-if st.session_state.quiz_started:
-    if st.session_state.current_question < len(st.session_state.selected_questions):
-        question_data = st.session_state.selected_questions[st.session_state.current_question]
-        st.subheader(f"문제 {st.session_state.current_question + 1}/{len(st.session_state.selected_questions)}")
-        st.write(question_data["question"])
+    # 퀴즈 진행
+    if st.session_state.quiz_started:
+        if st.session_state.current_question < len(st.session_state.selected_questions):
+            question_data = st.session_state.selected_questions[st.session_state.current_question]
+            st.subheader(f"문제 {st.session_state.current_question + 1}/{len(st.session_state.selected_questions)}")
+            st.write(question_data["question"])
 
-        # 힌트 표시 여부
-        if st.session_state.show_hint:
-            st.info(f"힌트: {question_data['hint']}")
+            if st.session_state.show_hint:
+                st.info(f"힌트: {question_data['hint']}")
 
-        # 힌트 보기 버튼
-        if st.button("힌트 보기", key=f"hint_{st.session_state.current_question}"):
-            st.session_state.show_hint = True
-            st.rerun()
-
-        # 사용자 답변
-        user_answer = st.text_input("답변 입력:", key=f"answer_{st.session_state.current_question}")
-
-        # 정답 제출
-        if st.button("제출", key=f"submit_{st.session_state.current_question}"):
-            correct = user_answer.strip().lower() == question_data["answer"].lower()
-            if correct:
-                st.session_state.feedback = "정답입니다! 🎉"
-                st.session_state.score += 1
-            else:
-                st.session_state.feedback = f"오답입니다. 정답은 '{question_data['answer']}' 입니다."
-            st.rerun()
-
-        # 피드백 표시
-        if st.session_state.feedback:
-            if "정답입니다" in st.session_state.feedback:
-                st.success(st.session_state.feedback)
-            else:
-                st.error(st.session_state.feedback)
-
-            if st.button("다음 문제"):
-                st.session_state.current_question += 1
-                st.session_state.show_hint = False
-                st.session_state.feedback = None
+            if st.button("힌트 보기", key=f"hint_{st.session_state.current_question}"):
+                st.session_state.show_hint = True
                 st.rerun()
-    else:
-        st.success("모든 문제를 완료했습니다!")
-        st.write(f"최종 점수: {st.session_state.score}/{len(st.session_state.selected_questions)}")
 
-        if st.button("자세한 결과 보기"):
-                    st.switch_page("pages/Results.py")
+            user_answer = st.text_input("답변 입력:", key=f"answer_{st.session_state.current_question}")
+
+            if st.button("제출", key=f"submit_{st.session_state.current_question}"):
+                correct = user_answer.strip().lower() == question_data["answer"].lower()
+                if correct:
+                    st.session_state.feedback = "정답입니다! 🎉"
+                    st.session_state.score += 1
+                else:
+                    st.session_state.feedback = f"오답입니다. 정답은 '{question_data['answer']}' 입니다."
+                st.rerun()
+
+            if st.session_state.feedback:
+                if "정답입니다" in st.session_state.feedback:
+                    st.success(st.session_state.feedback)
+                else:
+                    st.error(st.session_state.feedback)
+
+                if st.button("다음 문제"):
+                    st.session_state.current_question += 1
+                    st.session_state.show_hint = False
+                    st.session_state.feedback = None
+                    st.rerun()
+        else:
+            st.success("모든 문제를 완료했습니다!")
+            st.write(f"최종 점수: {st.session_state.score}/{len(st.session_state.selected_questions)}")
+
+            if st.button("퀴즈 다시 풀기"):
+                st.session_state.quiz_started = False  # 퀴즈 상태 초기화
+                st.session_state.current_page = "Main"
+                st.session_state.final_score = st.session_state.score  # 결과 페이지에 점수 전달
+                st.rerun()
+
+            if st.button("결과 페이지로 넘어가기"):
+                st.session_state.current_page = "Results"  # 페이지 전환 설정
+                st.session_state.final_score = st.session_state.score  # 결과 페이지에 점수 전달
+                st.rerun()
+
+# 페이지 전환
+if st.session_state.current_page == "Main":
+    main_page()
+elif st.session_state.current_page == "Results":
+    from pages.Results import results_page
+    results_page()


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #29 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- [ ] TODO
- [ ] 메인페이지에서 퀴즈를 풀고 저장된 user의 점수를 결과 페이지로 전달될 수 있게 수정하였습니다.

### 테스트 결과 or 스크린샷 (선택)
> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요